### PR TITLE
ci: use CHROMATIC_PROJECT_TOKEN secret instead of hardcoded token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,4 +101,4 @@ jobs:
       - name: Publish to Chromatic
         uses: chromaui/action@latest
         with:
-          projectToken: chpt_4ce7e3f28a30111
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
Replace the hardcoded Chromatic project token with the existing `CHROMATIC_PROJECT_TOKEN` repo secret.